### PR TITLE
Create a cache for file info

### DIFF
--- a/framework/analysis.py
+++ b/framework/analysis.py
@@ -150,7 +150,7 @@ class analysis:
   def SetParams(self):
     ''' Once the input files are set, calculate all the needed parameters '''
     if len(self.files) == 0: return
-    _nEvents, _nGenEvents, _nSumOfWeights, _isData = GetAllInfoFromFile(self.files)
+    _nEvents, _nGenEvents, _nSumOfWeights, _isData = GetAllInfoFromFile(self.files, cacheName=self.fileName)
     self.nEvents       = _nEvents
     self.nGenEvents    = _nGenEvents
     self.nSumOfWeights = _nSumOfWeights
@@ -294,7 +294,7 @@ class analysis:
     elif self.index == -1: print '[INFO] Secuential mode!'
     print '[INFO] Cross section: ', self.xsec
     if self.options != '': print '[INFO] Options = ', self.options
-    if self.verbose >= 1: GetProcessInfo(self.files)
+    if self.verbose >= 1: GetProcessInfo(self.files, process=self.fileName)
     if self.nSlots == 1: self.loop(first, last)
     else:                self.multiloop(first, last)
     self.log()

--- a/ttbar/processSample.py
+++ b/ttbar/processSample.py
@@ -40,7 +40,7 @@ def runSample(sample, options, path = '', nEv = -1):
     exit()
 
   #for sample in dic:
-  nEvents, nGenEvents, nSumOfWeights, isData = GetAllInfoFromFile([path + x for x in dic[sample]])
+  nEvents, nGenEvents, nSumOfWeights, isData = GetAllInfoFromFile([path + x for x in dic[sample]], cacheName=sample)
   thexsec = xsecdic[sample] if not isData else 1
   a = ttdilepton(path, sample, xsec = thexsec)
   a.SetOptions(options)


### PR DESCRIPTION
 (with verbose it is otherwise done three times before processing the samples)

This is not the cleanest (it could be done with a function decorator) nor safest (it assumes the list of files doesn't change, which is reasonable but not paranoid; in principle the cache should be locked when updating, to avoid corrupting the file if written from several processes simultaneously) implementation, but should be a good speedup in any case